### PR TITLE
BoilerPlate Fatal Error Message

### DIFF
--- a/HPL2/core/cmake/BoilerPlate.cmake
+++ b/HPL2/core/cmake/BoilerPlate.cmake
@@ -32,7 +32,7 @@ elseif (WIN32)
     set(CMAKE_EXECUTABLE_SUFFIX ".exe")
     add_compile_definitions(WIN32)  # FG's flag used instead of the predefined C++ macro _WIN32
 
-    MESSAGE(FATAL_ERROR "TODO Windows specific stuff")
+    # TODO Windows specific stuff
 else ()
     MESSAGE(FATAL_ERROR "Unhandled Platform")
 endif ()

--- a/HPL2/core/cmake/BoilerPlate.cmake
+++ b/HPL2/core/cmake/BoilerPlate.cmake
@@ -32,7 +32,7 @@ elseif (WIN32)
     set(CMAKE_EXECUTABLE_SUFFIX ".exe")
     add_compile_definitions(WIN32)  # FG's flag used instead of the predefined C++ macro _WIN32
 
-    # TODO Windows specific stuff
+    MESSAGE(WARNING "Windows builds are experimental and will likely produce broken programs.")
 else ()
     MESSAGE(FATAL_ERROR "Unhandled Platform")
 endif ()


### PR DESCRIPTION
Removed the fatal error message in "HPL2/core/cmake/BoilderPlate.cmake" which prevents compilation for WIN32.