### PR TITLE
CMakeLists Changes

### DIFF
--- a/HPL2/core/CMakeLists.txt
+++ b/HPL2/core/CMakeLists.txt
@@ -6,7 +6,11 @@ include(BoilerPlate)
 
 # Set up dependencies dirs (CACHE = global scope)
 set(DEPENDENCIES_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependencies/precompiled CACHE PATH "Dir which holds precompiled dependencies - libs and headers")
-set(DEPENDENCIES_PLATFORM_LIBS ${DEPENDENCIES_ROOT}/lib/${PLATFORM_PREFIX} CACHE PATH "Dir which holds prebuilt libraries for target system")
+if(MINGW)
+    set(DEPENDENCIES_PLATFORM_LIBS "${DEPENDENCIES_ROOT}/lib/mingw32;${DEPENDENCIES_ROOT}/lib/win32" CACHE PATH "Dir which holds prebuilt libraries for target system")
+else()
+    set(DEPENDENCIES_PLATFORM_LIBS ${DEPENDENCIES_ROOT}/lib/${PLATFORM_PREFIX} CACHE PATH "Dir which holds prebuilt libraries for target system")
+endif()
 
 include(UtilityFunctions)
 
@@ -185,7 +189,7 @@ if(MINGW)
 
     add_subdirectory(../../dependencies/AngelScript build_angelscript)
     target_link_libraries(HPL2 angelscript)
-elseif(WIN32)
+elseif(WIN32 AND NOT MINGW)
     FindPrebuiltLibrary(NEWTON_LIBRARY newton)
     FindPrebuiltLibrary(FBX_LIBRARY fbxsdk-2012.2-md)
     FindPrebuiltLibrary(GLEW_LIBRARY glew32)
@@ -241,7 +245,7 @@ if(MINGW)
         PRIVATE ../../dependencies/zlib
         PRIVATE ${ZCONF_DIR}
     )
-elseif(WIN32)
+elseif(WIN32 AND NOT MINGW)
     FindPrebuiltLibrary(ZLIB zlib)
     target_link_libraries(HPL2 ${ZLIB})
 else()

--- a/HPL2/tools/editors/CMakeLists.txt
+++ b/HPL2/tools/editors/CMakeLists.txt
@@ -115,7 +115,7 @@ file(GLOB_RECURSE leveleditor_sources
     LevelEditorWorld.cpp
     )
 
-if(WIN32)
+if(MINGW)
     # Level Editor Icon
     list(APPEND leveleditor_sources "leveleditor/LevelEditor.rc")
 endif()
@@ -232,7 +232,7 @@ file(GLOB_RECURSE modeleditor_sources
     ModelEditorWorld.cpp
 )
 
-if(WIN32)
+if(MINGW)
     # Model Editor Icon
     list(APPEND modeleditor_sources "modeleditor/ModelEditor.rc")
 endif()
@@ -302,7 +302,7 @@ file(GLOB_RECURSE particleeditor_sources
     ParticleEditorWorld.cpp
 )
 
-if(WIN32)
+if(MINGW)
     # Particle Editor Icon
     list(APPEND particleeditor_sources "particleeditor/ParticleEditor.rc")
 endif()
@@ -367,7 +367,7 @@ file(GLOB_RECURSE materialeditor_sources
     MaterialEditorMain.cpp
 )
 
-if(WIN32)
+if(MINGW)
     # Material Editor Icon
     list(APPEND materialeditor_sources "materialeditor/MaterialEditor.rc")
 endif()

--- a/amnesia/src/CMakeLists.txt
+++ b/amnesia/src/CMakeLists.txt
@@ -71,12 +71,7 @@ endif()
 
 add_subdirectory(../../HPL2/core build_core)
 add_subdirectory(game build_game)
-
-if(MINGW)
-    message(WARNING "Launcher target is not ready on MinGW yet and will not be built.")
-else()
-    add_subdirectory(launcher build_launcher)
-endif()
+add_subdirectory(launcher build_launcher)
 
 add_custom_target(GameRelease
     DEPENDS Amnesia Launcher

--- a/amnesia/src/game/CMakeLists.txt
+++ b/amnesia/src/game/CMakeLists.txt
@@ -29,14 +29,14 @@ else ()
     set(full_sources ${all_sources})
 endif ()
 
-if(LINUX)
-    add_compile_definitions(LINUX)
-elseif(WIN32)
+if(MINGW)
     # This does not propagate from BoilerPlate
     add_compile_definitions(WIN32)
-    # Include the resource file for Windows builds
+    # Include the Windows resource file for MinGW builds
     set(WINDOWS_RESOURCE_FILE "Lux.rc")
     list(APPEND full_sources ${WINDOWS_RESOURCE_FILE})
+elseif(LINUX)
+    add_compile_definitions(LINUX)
 endif()
 
 add_executable(AmnesiaCE ${full_sources})

--- a/amnesia/src/launcher/CMakeLists.txt
+++ b/amnesia/src/launcher/CMakeLists.txt
@@ -3,9 +3,13 @@ project(Launcher)
 
 FindPrebuiltLibrary(FLTK_LIBRARY fltk)
 
-if (WIN32)
+if(WIN32 AND NOT MINGW)
     FindPrebuiltLibrary(FLTK_IMAGES_LIBRARY fltkimages)
     FindPrebuiltLibrary(JPEG_LIBRARY fltkjpeg)
+elseif(MINGW)
+    FindPrebuiltLibrary(FLTK_LIBRARY libfltk)
+    FindPrebuiltLibrary(FLTK_IMAGES_LIBRARY libfltk_images)
+    FindPrebuiltLibrary(JPEG_LIBRARY libfltk_jpeg)
     # This does not propagate from BoilerPlate
     add_compile_definitions(WIN32)
 else()
@@ -19,8 +23,8 @@ set(launcher_sources
     QualityChooser.cpp
     LauncherHelper.cpp)
 
-# Include the resource file for Windows builds
-if(WIN32)
+# Include the Windows resource file for MinGW builds
+if(MINGW)
     set(WINDOWS_RESOURCE_FILE "Launcher.rc")
     list(APPEND launcher_sources ${WINDOWS_RESOURCE_FILE})
 endif()
@@ -29,6 +33,8 @@ add_executable(Launcher ${launcher_sources})
 
 target_link_libraries(Launcher HPL2 ${FLTK_IMAGES_LIBRARY} ${FLTK_LIBRARY} ${JPEG_LIBRARY})
 
-if (LINUX)
+if(MINGW)
+    target_link_libraries(Launcher "${CMAKE_CURRENT_SOURCE_DIR}/glut32.lib" comctl32)
+elseif(LINUX)
     target_link_libraries(Launcher X11 Xext Xft fontconfig)
 endif()

--- a/dependencies/OALWrapper/CMakeLists.txt
+++ b/dependencies/OALWrapper/CMakeLists.txt
@@ -17,9 +17,15 @@ else()
     message(WARNING "DEPENDENCIES_ROOT not set. Build will probably fail to find dependencies in the system.")
 endif()
 
-# Check platform lib dir
-if(NOT EXISTS ${DEPENDENCIES_PLATFORM_LIBS})
-    message(FATAL_ERROR "Platform lib dir (DEPENDENCIES_PLATFORM_LIBS) not found")
+# Check platform lib dirs individually
+if(DEPENDENCIES_PLATFORM_LIBS)
+    foreach(DIR ${DEPENDENCIES_PLATFORM_LIBS})
+        if(NOT EXISTS ${DIR})
+            message(FATAL_ERROR "Platform lib dir (${DIR}) not found")
+        endif()
+    endforeach()
+else()
+    message(FATAL_ERROR "DEPENDENCIES_PLATFORM_LIBS is not set.")
 endif()
 
 


### PR DESCRIPTION
### Changelog Description

#### CMakeLists Changes

A handful of changes were made to the following `CMakeLists.txt` files:
- **HPL2 Core**
- **HPL2 Editors**
- **Amnesia Source**
- **Amnesia Game**
- **Amnesia Launcher**
- **OALWrapper**

These changes address improper use of the `WIN32` and `MINGW` conditionals. Additionally, I have ensured that MINGW builds utilize both the `win32` and `mingw32` dependency folders.

#### OALWrapper Configuration

Due to the way the OALWrapper checks for library directories, my changes initially caused an error during configuration. To resolve this, I modified the directory check to allow for additional directories, such as when building with MINGW.

#### Additional Dependency Folder

The additional dependency folder `mingw32`, populated with the MinGW32 FLTK libraries, was introduced in [PR #56](https://github.com/TiManGames/AmnesiaTheDarkDescent/pull/56).